### PR TITLE
ASSISTANT -> AGENT

### DIFF
--- a/docs/src/content/docs/api/calls.mdx
+++ b/docs/src/content/docs/api/calls.mdx
@@ -445,14 +445,14 @@ Lists all messages generated during the given call.
       <tr>
         <td class="font-mono text-sm">role</td>
         <td>string</td>
-        <td>Role that generated the message. Corresponds to one of the following: `USER` or `ASSISTANT`.</td>
+        <td>Role that generated the message. Corresponds to one of the following: `USER` or `AGENT`.</td>
       </tr>
       <tr>
         <td class="font-mono text-sm">text</td>
         <td>string</td>
         <td>The message text.</td>
       </tr>
-    </table>    
+    </table>
   </TabItem>
 </Tabs>
 
@@ -501,7 +501,7 @@ Call recordings are only generated if you add `"recordingEnabled": true` to the 
         <td>string</td>
         <td>Only returned if call recording was not enabled. If a recording was enabled, there is no response body and the call recording location is provided via a 302 redirect.</td>
       </tr>
-    </table>    
+    </table>
   </TabItem>
 </Tabs>
 
@@ -513,7 +513,7 @@ Call recordings are only generated if you add `"recordingEnabled": true` to the 
   curl --request GET \
   --url https://api.ultravox.ai/api/voices \
   --header 'X-API-Key: aBCDef.123456'
-  
+
   ```
   </TabItem>
   <TabItem label="JavaScript">

--- a/docs/src/content/docs/api/tools.mdx
+++ b/docs/src/content/docs/api/tools.mdx
@@ -5,7 +5,7 @@ sidebar:
 ---
 import { Badge, Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
-Tools in Ultravox allow you to extend the capabilities of your AI assistant by giving it access to external APIs and services. With tools, your AI can perform actions like fetching real-time data, interacting with databases, or integrating with third-party services, all while maintaining a natural conversation flow.
+Tools in Ultravox allow you to extend the capabilities of your AI agent by giving it access to external APIs and services. With tools, your AI can perform actions like fetching real-time data, interacting with databases, or integrating with third-party services, all while maintaining a natural conversation flow.
 
 :::danger[Use ultravox-70B for Tools]
 Currently, Ultravox only supports tools with our 70B model. Make sure to set the model to `fixie-ai/ultravox-70B` in any calls where you want to use tools.


### PR DESCRIPTION
We were previously inconsistent about this in the API, though the SDKs all consistently use "agent".  As of https://github.com/fixie-ai/fixie/pull/3011 the API consistently uses "agent" now too.