### PR TITLE
Add phone calls & available models

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,6 +35,10 @@ export default defineConfig({
         link: 'guides/quickstart'
       },
       {
+        label: 'Phone Calls',
+        link: 'guides/phonecalls'
+      },
+      {
         label: 'Tools in Ultravox',
         link: '/tools'
       },

--- a/docs/src/content/docs/api/calls.mdx
+++ b/docs/src/content/docs/api/calls.mdx
@@ -149,7 +149,7 @@ An optional query parameter called `priorCallId` can be provided to continue a p
       <tr>
         <td class="font-mono">initator</td>
         <td>string</td>
-        <td>Who was responsible for staring this call. Typically set to agent for outgoing calls and left as the default (user) otherwise.<br />Can be `"agent"` or `"user"` (default).</td>
+        <td>Who was responsible for staring this call. Typically set to INITIATOR_AGENT for outgoing calls and left as the default (INITIATOR_USER) otherwise.</td>
       </tr>
       <tr>
         <td class="font-mono">languageHint</td>

--- a/docs/src/content/docs/api/calls.mdx
+++ b/docs/src/content/docs/api/calls.mdx
@@ -98,7 +98,7 @@ Lists all calls that have been created. Account scoped.
       <tr>
         <td class="font-mono">maxDuration</td>
         <td>string</td>
-        <td>Maximum length that was set for the call. Format is `HH:MM:SS`.</td>
+        <td>Maximum length (in seconds) that was set for the call.</td>
       </tr>
       <tr>
         <td class="font-mono">timeExceededMessage</td>
@@ -149,7 +149,7 @@ An optional query parameter called `priorCallId` can be provided to continue a p
       <tr>
         <td class="font-mono">initator</td>
         <td>string</td>
-        <td>Who was responsible for staring this call. Typically set to INITIATOR_AGENT for outgoing calls and left as the default (INITIATOR_USER) otherwise.</td>
+        <td>Who was responsible for starting this call. Typically set to INITIATOR_AGENT for outgoing calls and left as the default (INITIATOR_USER) otherwise.</td>
       </tr>
       <tr>
         <td class="font-mono">languageHint</td>
@@ -159,7 +159,7 @@ An optional query parameter called `priorCallId` can be provided to continue a p
       <tr>
         <td class="font-mono">maxDuration</td>
         <td>string</td>
-        <td>Maximum length for the call in the format `HH:MM:SS`. Can be used to limit the length of the call. Optionally, set `timeExceededMessage` to have the agent say a message when the allotted time is reached.<br /><br />For the free plan, defaults to amount of free time remaining (less any calls that are currently in-progress). For paid plans, defaults to the system maximum of one hour ("01:00:00"). </td>
+        <td>Maximum length (in seconds) for the call. Must contain `s` and can be fractional. E.g. `300s` or `245.5s`. Used to limit the length of the call. Optionally, set `timeExceededMessage` to have the agent say a message when the allotted time is reached.<br /><br />For the free plan, defaults to amount of free time remaining (less any calls that are currently in-progress). For paid plans, defaults to the system maximum of one hour ("3600s"). </td>
       </tr>
       <tr>
         <td class="font-mono">medium</td>
@@ -253,7 +253,7 @@ An optional query parameter called `priorCallId` can be provided to continue a p
       <tr>
         <td class="font-mono">maxDuration</td>
         <td>string</td>
-        <td>Maximum length that was set for the call. Format is `HH:MM:SS`.</td>
+        <td>Maximum length (in seconds) that was set for the call.</td>
       </tr>
       <tr>
         <td class="font-mono">timeExceededMessage</td>

--- a/docs/src/content/docs/api/calls.mdx
+++ b/docs/src/content/docs/api/calls.mdx
@@ -73,7 +73,7 @@ Lists all calls that have been created. Account scoped.
       <tr>
         <td class="font-mono">model</td>
         <td>string</td>
-        <td>Name of the model used for the call. Currently only `fixie-ai/ultravox` is supported.</td>
+        <td>Name of the model used for the call.</td>
       </tr>
       <tr>
         <td class="font-mono">systemPrompt</td>
@@ -147,9 +147,9 @@ An optional query parameter called `priorCallId` can be provided to continue a p
         <th class="w-10/12"></th>
       </tr>
       <tr>
-        <td class="font-mono">systemPrompt <br /> <span class="text-sm text-red-500">required</span></td>
+        <td class="font-mono">initator</td>
         <td>string</td>
-        <td>The system prompt to use for the AI.</td>
+        <td>Who was responsible for staring this call. Typically set to agent for outgoing calls and left as the default (user) otherwise.<br />Can be `"agent"` or `"user"` (default).</td>
       </tr>
       <tr>
         <td class="font-mono">languageHint</td>
@@ -157,9 +157,19 @@ An optional query parameter called `priorCallId` can be provided to continue a p
         <td>A hint about the language to be used if your end users are speaking a language other than English. Must be a valid BCP47 language code. Best effort is made to select the closest supported language.  (default: "en")</td>
       </tr>
       <tr>
+        <td class="font-mono">maxDuration</td>
+        <td>string</td>
+        <td>Maximum length for the call in the format `HH:MM:SS`. Can be used to limit the length of the call. Optionally, set `timeExceededMessage` to have the agent say a message when the allotted time is reached.<br /><br />For the free plan, defaults to amount of free time remaining (less any calls that are currently in-progress). For paid plans, defaults to the system maximum of one hour ("01:00:00"). </td>
+      </tr>
+      <tr>
+        <td class="font-mono">medium</td>
+        <td>object</td>
+        <td>Details about a call's protocol. By default, calls occur over WebRTC using the Ultravox client SDK. Setting a different call medium will prepare the server for a call using a different protocol. At most one call medium may be set.<br />Can be `"webRtc":{}` (default) or `"twilio":{}`.</td>
+      </tr>
+      <tr>
         <td class="font-mono">model</td>
         <td>string</td>
-        <td>The model to be used for the call. Currently only `fixie-ai/ultravox` is supported and is the default.</td>
+        <td>The model to be used for the call. If not specified, defaults to `fixie-ai/ultravox`. See [available models](../../availablemodels/).</td>
       </tr>
       <tr>
         <td class="font-mono">recordingEnabled</td>
@@ -167,19 +177,19 @@ An optional query parameter called `priorCallId` can be provided to continue a p
         <td>A recording will be saved for the call when set to `true`. Recording can be retrieved via `GET /calls/{call_id}/recording`. Default value of `false`.</td>
       </tr>
       <tr>
+        <td class="font-mono">selectedTools</td>
+        <td>array</td>
+        <td>Each object is a tool selected for the call.</td>
+      </tr>
+      <tr>
+        <td class="font-mono">systemPrompt <br /> <span class="text-sm text-red-500">required</span></td>
+        <td>string</td>
+        <td>The system prompt to use for the AI.</td>
+      </tr>
+      <tr>
         <td class="font-mono">temperature</td>
         <td>float</td>
         <td>The temperature setting for the model. Value between 0.0 and 1.0. (default: 0.0)</td>
-      </tr>
-      <tr>
-        <td class="font-mono">voice</td>
-        <td>string</td>
-        <td>The voice the AI will use for speaking. There are currently two options: `lily` (default) and `terrence`. Please contact us if you have other voice requirements.</td>
-      </tr>
-      <tr>
-        <td class="font-mono">maxDuration</td>
-        <td>string</td>
-        <td>Maximum length for the call in the format `HH:MM:SS`. Can be used to limit the length of the call. Optionally, set `timeExceededMessage` to have the agent say a message when the allotted time is reached.<br /><br />For the free plan, defaults to amount of free time remaining (less any calls that are currently in-progress). For paid plans, defaults to the system maximum of one hour ("01:00:00"). </td>
       </tr>
       <tr>
         <td class="font-mono">timeExceededMessage</td>
@@ -187,9 +197,9 @@ An optional query parameter called `priorCallId` can be provided to continue a p
         <td>Message that the agent will say if the call reaches the `maxDuration`.</td>
       </tr>
       <tr>
-        <td class="font-mono">joinUrl</td>
+        <td class="font-mono">voice</td>
         <td>string</td>
-        <td>URL to use with the ultravox client library to join (AKA start) the call.</td>
+        <td>The voice the AI will use for speaking. There are currently two options: `lily` (default) and `terrence`. Please contact us if you have other voice requirements.</td>
       </tr>
     </table>
   </TabItem>
@@ -218,7 +228,7 @@ An optional query parameter called `priorCallId` can be provided to continue a p
       <tr>
         <td class="font-mono">model</td>
         <td>string</td>
-        <td>Name of the model used for the call. Currently only `fixie-ai/ultravox` is supported.</td>
+        <td>Name of the model used for the call.</td>
       </tr>
       <tr>
         <td class="font-mono">systemPrompt</td>
@@ -317,7 +327,7 @@ Gets details for the call with `call_id` specified in the path. Account scoped.
       <tr>
         <td class="font-mono">model</td>
         <td>string</td>
-        <td>Name of the model used for the call. Currently only `fixie-ai/ultravox` is supported.</td>
+        <td>Name of the model used for the call.</td>
       </tr>
       <tr>
         <td class="font-mono">systemPrompt</td>

--- a/docs/src/content/docs/api/tools.mdx
+++ b/docs/src/content/docs/api/tools.mdx
@@ -22,7 +22,7 @@ Read [Tools in Ultravox](../tools) for loads of information about tool types, au
 :::
 
 :::danger[Use ultravox-70B for Tools]
-Currently, Ultravox only supports tools with our 70B model. Make sure to set the model to `fixie-ai/ultravox-70B` in any calls where you want to use tools.
+Currently, Ultravox only supports tools with our 70B model. See [available models](../../availablemodels/) for more info.
 :::
 
 

--- a/docs/src/content/docs/api/tools.mdx
+++ b/docs/src/content/docs/api/tools.mdx
@@ -22,7 +22,7 @@ Read [Tools in Ultravox](../tools) for loads of information about tool types, au
 :::
 
 :::danger[Use ultravox-70B for Tools]
-Currently, Ultravox only supports tools with our 70B model. See [available models](../../availablemodels/) for more info.
+While tools are supported across multiple variants of the Ultravox model, using tools with smaller models (i.e. 8B) typically don't work well. YMMV. See [available models](../../availablemodels/) for more info.
 :::
 
 

--- a/docs/src/content/docs/availablemodels.mdx
+++ b/docs/src/content/docs/availablemodels.mdx
@@ -19,7 +19,7 @@ The Ultravox API currently provides the following models.
     </tr>
     <tr>
         <td class="font-mono">fixie-ai/ultravox-8B</td>
-        <td>8B variant of Ultravox. Not recommended for most use cases. Does not support tools.</td>
+        <td>8B variant of Ultravox. Not recommended for most use cases. Tools are unlikely to work.</td>
     </tr>
 </table>
 

--- a/docs/src/content/docs/availablemodels.mdx
+++ b/docs/src/content/docs/availablemodels.mdx
@@ -1,0 +1,35 @@
+---
+  title: "Available Models"
+---
+
+The Ultravox API currently provides the following models.
+
+<table class="w-full">
+    <tr class="w-full">
+        <th class="w-4/12">Model</th>
+        <th class="w-8/12">Description</th>
+    </tr>
+    <tr>
+        <td class="font-mono">fixie-ai/ultravox</td>
+        <td>This is an alias that points to `ultravox-70B`. The default if no model is specified when creating a call with the API.</td>
+    </tr>
+    <tr>
+        <td class="font-mono">fixie-ai/ultravox-70B</td>
+        <td>70B variant of Ultravox. Supports tools.</td>
+    </tr>
+    <tr>
+        <td class="font-mono">fixie-ai/ultravox-8B</td>
+        <td>8B variant of Ultravox. Not recommended for most use cases. Does not support tools.</td>
+    </tr>
+</table>
+
+## Using Models
+Each model can be used when [creating a call](./api/calls/#create-call) via the API. For example:
+
+```javascript
+// Example request body to create an Ultravox call
+{
+  "systemPrompt": "You are a helpful assistant...",
+  "model": "fixie-ai/ultravox-70B"
+}
+```

--- a/docs/src/content/docs/guides/phonecalls.mdx
+++ b/docs/src/content/docs/guides/phonecalls.mdx
@@ -38,7 +38,7 @@ Creating an Ultravox call that works with Twilio is just like creating a WebRTC 
     <tr>
         <td class="font-mono">initiator</td>
         <td>string</td>
-        <td>Tells Ultravox who is responsible for starting the call. For outgoing calls, typically set to `"agent"`. Default is `"user"`.</td>
+        <td>Tells Ultravox who started the call. For outgoing calls, typically set to `"INITIATOR_AGENT"`. Default is `"INITIATOR_USER"`.</td>
     </tr>
 </table>
 

--- a/docs/src/content/docs/guides/phonecalls.mdx
+++ b/docs/src/content/docs/guides/phonecalls.mdx
@@ -1,0 +1,113 @@
+---
+title: "Phone Calls"
+description: Use Ultravox API to make and receive calls from regular phones via Twilio.
+---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+## Overview
+
+The Ultravox API allows you to create AI-powered voice applications that can interact with regular phone numbers. This enables Ultravox AI agents to make outgoing calls and receive incoming calls from traditional phone networks.
+
+:::note[Twilio Support]
+We currently integrate with Twilio. Please let us know if there's another integration you'd like to see.
+:::
+
+This guide will walk you through the process of setting up and using the Ultravox API with Twilio for both outgoing and incoming phone calls.
+
+## Creating a Phone Call with Twilio
+:::tip[Prerequisites]
+Make sure you have:
+1. An active Twilio account
+1. A phone number purchased from Twilio
+:::
+
+Creating an Ultravox call that works with Twilio is just like creating a WebRTC call except you must add two additional parameters to the [Create Call](./api/calls/#create-call) command:
+
+<table class="w-full">
+    <tr class="w-full">
+        <th class="w-1/12"></th>
+        <th class="w-1/12"></th>
+        <th class="w-10/12"></th>
+    </tr>
+    <tr>
+        <td class="font-mono">medium</td>
+        <td>object</td>
+        <td>Tells Ultravox which protocol to use. <br />For Twilio, must be set to `{"twilio": {}}` and sets the call to use Twilio [Media Streams](https://www.twilio.com/docs/voice/media-streams). Defaults to `{"webRtc": {}}` which sets the protocol to WebRTC.</td>
+    </tr>
+    <tr>
+        <td class="font-mono">initiator</td>
+        <td>string</td>
+        <td>Tells Ultravox who is responsible for starting the call. For outgoing calls, typically set to `"agent"`. Default is `"user"`.</td>
+    </tr>
+</table>
+
+Adding these to the request body when creating the call would look like this:
+
+```javascript
+{
+  "systemPrompt": "You are a helpful assistant...",
+  ...
+  "medium": {
+    "twilio": {}
+  },
+  "initiator": "agent"
+}
+```
+
+Ultravox will return a `joinUrl` that can then be used with Twilio for outgoing or incoming calls.
+
+## Outgoing Calls
+
+It only takes two steps to make an outgoing call to regular phone numbers through Twilio:
+<Steps>
+1. **Create an Ultravox Call** → Create a new call (see [above](#creating-a-phone-call-with-twilio)), and get a `joinUrl`.
+
+1. **Initiate Twilio Phone call** → Use the `joinUrl` with a Twilio [`<Stream>`](https://www.twilio.com/docs/voice/twiml/stream).
+
+    ```javascript
+    // Example using the twilio node library
+    const call = await client.calls.create({
+        twiml: `<Response>
+                    <Connect>
+                        <Stream url="${joinUrl}"/>
+                    </Connect>
+                </Response>`,
+        to: phoneNumber, // the number you are calling
+        from: twilioPhoneNumber // your twilio number
+    });
+    ```
+</Steps>
+
+See the [twilio-outgoing-call](https://github.com/fixie-ai/ultradox/tree/main/examples/twilio-outgoing-call) example for more.
+
+This example shows one of the many options Twilio provides for making outgoing calls. Consult the [Twilio docs](https://www.twilio.com/docs) for more details.
+
+## Incoming Calls
+Incoming calls require essentially the same two steps as outgoing calls:
+
+<Steps>
+1. **Create an Ultravox Call** → Create a new call (see [above](#creating-a-phone-call-with-twilio)), and get a `joinUrl`. *Note: for incoming calls you will want to keep `initiator` set to the default ("user").*
+
+1. **Receive Inbound Twilio Phone call** → Use the `joinUrl` with a Twilio [`<Stream>`](https://www.twilio.com/docs/voice/twiml/stream).
+
+    ```xml
+    <!-- Example using a TwiML Bin -->
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Response>
+        <Connect>
+            <Stream url="your_ultravox_join_url" />
+        </Connect>
+    </Response>
+
+    ```
+</Steps>
+
+The above shows how to create a TwiML Bin and use that for handling the inbound call. Consult the [Twilio docs](https://www.twilio.com/docs) for more on all the options Twilio provides for handling phone calls.
+
+
+## Conclusion
+
+By integrating the Ultravox API with Twilio, you can create powerful AI-driven voice applications that interact with regular phone networks. This opens up a wide range of possibilities for customer service, automated outreach, and other voice-based AI applications.
+
+For more information on Twilio, refer to the [Twilio documentation](https://www.twilio.com/docs).

--- a/docs/src/content/docs/guides/phonecalls.mdx
+++ b/docs/src/content/docs/guides/phonecalls.mdx
@@ -51,7 +51,7 @@ Adding these to the request body when creating the call would look like this:
   "medium": {
     "twilio": {}
   },
-  "initiator": "agent"
+  "initiator": "INITIATOR_AGENT"
 }
 ```
 

--- a/docs/src/content/docs/guides/phonecalls.mdx
+++ b/docs/src/content/docs/guides/phonecalls.mdx
@@ -22,7 +22,7 @@ Make sure you have:
 1. A phone number purchased from Twilio
 :::
 
-Creating an Ultravox call that works with Twilio is just like creating a WebRTC call except you must add two additional parameters to the [Create Call](./api/calls/#create-call) command:
+Creating an Ultravox call that works with Twilio is just like creating a WebRTC call, but there are two parameters to the [Create Call](./api/calls/#create-call) command worth special attention:
 
 <table class="w-full">
     <tr class="w-full">


### PR DESCRIPTION
New page for phone calls (with twilio). Updated /calls to add params for medium & initiator. "Available models" page lists out models and removed reference to "we only have one model" and point to this new page.