### PR TITLE
removing state from examples

### DIFF
--- a/docs/src/content/codesnippets/sdk/quickstart-dart.txt
+++ b/docs/src/content/codesnippets/sdk/quickstart-dart.txt
@@ -1,0 +1,6 @@
+import 'package:ultravox_client/ultravox_client.dart';
+
+UltravoxSession session = UltravoxSession.create();
+await _session.joinCall('wss://your-call-join-url');
+
+await session.leaveCall();

--- a/docs/src/content/codesnippets/sdk/quickstart-js.txt
+++ b/docs/src/content/codesnippets/sdk/quickstart-js.txt
@@ -1,0 +1,6 @@
+import { UltravoxSession } from 'ultravox-client';
+
+const session = new UltravoxSession();
+session.joinCall('wss://your-call-join-url');
+
+session.leaveCall();

--- a/docs/src/content/codesnippets/sdk/quickstart-kotlin.txt
+++ b/docs/src/content/codesnippets/sdk/quickstart-kotlin.txt
@@ -1,0 +1,6 @@
+import ai.ultravox.UltravoxSession
+
+val session = UltravoxSession()
+session.joinCall("wss://your-call-join-url")
+
+session.leaveCall()

--- a/docs/src/content/codesnippets/sdk/quickstart-python.txt
+++ b/docs/src/content/codesnippets/sdk/quickstart-python.txt
@@ -1,0 +1,7 @@
+import asyncio
+import ultravox_client as uv
+
+session = await uv.UltravoxSession()
+session.join_call("wss://your-call-join-url")
+
+await session.leave_call()

--- a/docs/src/content/docs/sdk.mdx
+++ b/docs/src/content/docs/sdk.mdx
@@ -8,55 +8,32 @@ import { Tabs, TabItem, Code, Steps } from '@astrojs/starlight/components';
 import SDKCards from '@components/SDKCards.astro';
 import CallOut from '@components/CallOut.astro';
 
+
 The Ultravox [REST API](../api/auth/) is used to create calls but you must use one of the Ultravox client SDKs to join and end calls. This page primarily uses examples in JavaScript. The concepts are the same across all the [different SDK implementations](#sdk-implementations).
 
 ## Ultravox Session
 The core of the SDK is the `UltravoxSession`. The session is used to join and leave calls.
 
+import quickstartdart from '../codesnippets/sdk/quickstart-dart.txt?raw';
+import quickstartjs from '../codesnippets/sdk/quickstart-js.txt?raw';
+import quickstartkotlin from '../codesnippets/sdk/quickstart-kotlin.txt?raw';
+import quickstartpython from '../codesnippets/sdk/quickstart-python.txt?raw';
+
 <Tabs syncKey="example-language">
   <TabItem label="JavaScript">
-    ```js
-    import { UltravoxSession } from 'ultravox-client';
-
-    const session = new UltravoxSession();
-    const state = await session.joinCall('wss://your-call-join-url');
-
-    session.leaveCall();
-    ```
+    <Code code={quickstartjs} lang="js" />
   </TabItem>
 
   <TabItem label="Flutter">
-    ```dart
-    import 'package:ultravox_client/ultravox_client.dart';
-
-    UltravoxSession session = UltravoxSession.create();
-    UltravoxSessionState state = await _session.joinCall('wss://your-call-join-url');
-
-    await session.leaveCall();
-    ```
+    <Code code={quickstartdart} lang="dart" />
   </TabItem>
 
   <TabItem label="Kotlin">
-    ```kotlin
-    import ai.ultravox.UltravoxSession
-
-    val session = UltravoxSession()
-    val state = session.joinCall("wss://your-call-join-url")
-
-    session.leaveCall()
-    ```
+    <Code code={quickstartkotlin} lang="kotlin" />
   </TabItem>
 
   <TabItem label="Python">
-    ```python
-    import asyncio
-    import ultravox_client as uv
-
-    session = uv.UltravoxSession()
-    state = await session.join_call("wss://your-call-join-url")
-
-    await session.leave_call()
-    ```
+    <Code code={quickstartpython} lang="python" />
   </TabItem>
 </Tabs>
 

--- a/examples/drdonut-nextjs/package.json
+++ b/examples/drdonut-nextjs/package.json
@@ -13,7 +13,7 @@
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",
-    "ultravox-client": "^0.2.9"
+    "ultravox-client": "^0.3.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/examples/drdonut-nextjs/pnpm-lock.yaml
+++ b/examples/drdonut-nextjs/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
       ultravox-client:
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.3.2
+        version: 0.3.2
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -346,8 +346,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@livekit/protocol@1.19.1':
-    resolution: {integrity: sha512-PQYIuqRv++fRik9tKulJ0C0tT5O4cNviBA7OxwLTCBFDxJpve8ua8/JZ+nK+7r4j2KbLfVjsJYop9wcTCgRn7Q==}
+  '@livekit/protocol@1.24.0':
+    resolution: {integrity: sha512-9dCsqnkMn7lvbI4NGh18zhLDsrXyUcpS++TEFgEk5Xv1WM3R2kT3EzqgL1P/mr3jaabM6rJ8wZA/KJLuQNpF5w==}
 
   '@next/env@14.2.5':
     resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
@@ -1380,8 +1380,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  livekit-client@2.4.2:
-    resolution: {integrity: sha512-6iEeDiaon9TvH0L0t34wSApGk6In8Rpl538Dgh9hrxts2kq0scuxMTz2ipagFVIVGYOKceKBA2dnv/XOL+1ACw==}
+  livekit-client@2.5.9:
+    resolution: {integrity: sha512-oDpK6SKYB1F+mNO+25DA0bF0cD2XoOJeD8ji4YQpzDBQv2IxeyKrQhoqXAqrYgIKuiMNkImSf+yg2v7EHSl4Og==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1898,6 +1898,9 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1930,8 +1933,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ultravox-client@0.2.9:
-    resolution: {integrity: sha512-4bASHuKvD81NwpGB5cuR3JQONGQZHt1oEUeNYNycsLm1ayQ/AFiUuYW+rpa6qpefgPMqozRntwr9CnDgeY1KKw==}
+  ultravox-client@0.3.2:
+    resolution: {integrity: sha512-Z+j1efzyIxOVbjqo8ZcaQTKLoYbPRDa5EIwCcqK6r2CfP5xtKe3fBsiOs81mF0Eq4wyMtvOp8mapT+3S44z+5g==}
     engines: {pnpm: '>=6.0.0'}
 
   unbox-primitive@1.0.2:
@@ -2307,7 +2310,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@livekit/protocol@1.19.1':
+  '@livekit/protocol@1.24.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
@@ -3519,14 +3522,14 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  livekit-client@2.4.2:
+  livekit-client@2.5.9:
     dependencies:
-      '@livekit/protocol': 1.19.1
+      '@livekit/protocol': 1.24.0
       events: 3.3.0
       loglevel: 1.9.1
       sdp-transform: 2.14.2
       ts-debounce: 4.0.0
-      tslib: 2.6.3
+      tslib: 2.7.0
       typed-emitter: 2.1.0
       webrtc-adapter: 9.0.1
 
@@ -3855,7 +3858,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.7.0
     optional: true
 
   safe-array-concat@1.1.2:
@@ -4085,6 +4088,8 @@ snapshots:
 
   tslib@2.6.3: {}
 
+  tslib@2.7.0: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4129,9 +4134,9 @@ snapshots:
 
   typescript@5.5.4: {}
 
-  ultravox-client@0.2.9:
+  ultravox-client@0.3.2:
     dependencies:
-      livekit-client: 2.4.2
+      livekit-client: 2.5.9
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/examples/drdonut-nextjs/utils/callFunctions.ts
+++ b/examples/drdonut-nextjs/utils/callFunctions.ts
@@ -1,6 +1,6 @@
 'use client';
 import { UltravoxSession, UltravoxSessionStatus, Transcript } from 'ultravox-client';
-let UVSession: UltravoxSession | null = null;
+let uvSession: UltravoxSession | null = null;
 
 interface JoinUrlResponse {
   uuid: string;
@@ -18,8 +18,8 @@ interface CallCallbacks {
 }
 
 const initUVSession = async () => {
-  if (!UVSession) {
-    UVSession = new UltravoxSession();
+  if (!uvSession) {
+    uvSession = new UltravoxSession();
   }
 };
 
@@ -53,31 +53,33 @@ export async function startCall(callbacks: CallCallbacks): Promise<() => void> {
 
     await initUVSession();
 
-    if (UVSession) {
-      UVSession.joinCall(joinUrl);
-      console.log('Session status:', UVSession.status);
-    } else {
-      return () => {};
-    }
-
     const statusChangeListener = (event: any) => {
-      callbacks.onStatusChange(UVSession?.status);
+      callbacks.onStatusChange(uvSession?.status);
     };
 
     const transcriptChangeListener = (event: any) => {
-      console.log(UVSession?.transcripts);
-      callbacks.onTranscriptChange(UVSession?.transcripts);
+      console.log(uvSession?.transcripts);
+      callbacks.onTranscriptChange(uvSession?.transcripts);
     };
 
-    UVSession.addEventListener('status', statusChangeListener);
-    UVSession.addEventListener('transcripts', transcriptChangeListener);
+    if (uvSession) {
+      
+  
+      uvSession.addEventListener('status', statusChangeListener);
+      uvSession.addEventListener('transcripts', transcriptChangeListener);
+
+      uvSession.joinCall(joinUrl);
+      console.log('Session status:', uvSession.status);
+    } else {
+      return () => {};
+    }
 
     console.log('Call started!');
 
     // For cleaning up when calls end
     return () => {
-      UVSession?.removeEventListener('status', statusChangeListener);
-      UVSession?.removeEventListener('transcripts', transcriptChangeListener);
+      uvSession?.removeEventListener('status', statusChangeListener);
+      uvSession?.removeEventListener('transcripts', transcriptChangeListener);
     };
   }
 }
@@ -85,8 +87,8 @@ export async function startCall(callbacks: CallCallbacks): Promise<() => void> {
 export async function endCall(): Promise<void> {
   console.log('Call ended.');
 
-  if (UVSession) {
-    UVSession.leaveCall();
-    UVSession = null;
+  if (uvSession) {
+    uvSession.leaveCall();
+    uvSession = null;
   }
 }

--- a/examples/quickstart-js/main.js
+++ b/examples/quickstart-js/main.js
@@ -1,4 +1,4 @@
-import { UltravoxSession, UltravoxSessionStatus } from 'ultravox-client';
+import { UltravoxSession } from 'ultravox-client';
 const apiUrl = 'http://localhost:3000/startCall';
 const expMessages = new Set(["debug"]);
 let UVSession = new UltravoxSession({ experimentalMessages: expMessages });
@@ -37,21 +37,21 @@ export async function startCall() {
   } else {
     console.log('Joining call:', joinUrl);
 
-    const state = UVSession.joinCall(joinUrl);
-    appendToConversation(`Joining call: ${state.getStatus()}`);
-    console.log('Session status:', state.getStatus());
+    UVSession.joinCall(joinUrl);
+    appendToConversation(`Joining call: ${UVSession.status}`);
+    console.log('Session status:', UVSession.status);
 
-    state.addEventListener('ultravoxSessionStatusChanged', (event) => {
-      console.log('Session status changed:', event.state);
-      appendToConversation(`Session status changed: ${event.state}`);
+    UVSession.addEventListener('status', (event) => {
+      console.log('Session status changed:', UVSession.status);
+      appendToConversation(`Session status changed: ${UVSession.status}`);
     });
 
-    state.addEventListener('ultravoxTranscriptsChanged', (event) => {
-      console.log('Transcripts changed:', event.transcripts);
-      appendToConversation(`Transcripts changed: ${JSON.stringify(event.transcripts)}`);
+    UVSession.addEventListener('transcripts', (event) => {
+      console.log('Transcripts changed:', UVSession.transcripts);
+      appendToConversation(`Transcripts changed: ${JSON.stringify(UVSession.transcripts)}`);
     });
 
-    state.addEventListener('ultravoxExperimentalMessage', (event) => {
+    UVSession.addEventListener('experimental_message', (event) => {
       console.log('Exp Message:', event);
     });
   }

--- a/examples/quickstart-js/main.js
+++ b/examples/quickstart-js/main.js
@@ -1,7 +1,7 @@
 import { UltravoxSession } from 'ultravox-client';
 const apiUrl = 'http://localhost:3000/startCall';
 const expMessages = new Set(["debug"]);
-let UVSession = new UltravoxSession({ experimentalMessages: expMessages });
+let uvSession = new UltravoxSession({ experimentalMessages: expMessages });
 
 async function getJoinUrl(systemPrompt) {
   console.log('getJoinUrl called');
@@ -37,23 +37,25 @@ export async function startCall() {
   } else {
     console.log('Joining call:', joinUrl);
 
-    UVSession.joinCall(joinUrl);
-    appendToConversation(`Joining call: ${UVSession.status}`);
-    console.log('Session status:', UVSession.status);
-
-    UVSession.addEventListener('status', (event) => {
-      console.log('Session status changed:', UVSession.status);
-      appendToConversation(`Session status changed: ${UVSession.status}`);
+    uvSession.addEventListener('status', (event) => {
+      console.log('Session status changed:', uvSession.status);
+      appendToConversation(`Session status changed: ${uvSession.status}`);
     });
 
-    UVSession.addEventListener('transcripts', (event) => {
-      console.log('Transcripts changed:', UVSession.transcripts);
-      appendToConversation(`Transcripts changed: ${JSON.stringify(UVSession.transcripts)}`);
+    uvSession.addEventListener('transcripts', (event) => {
+      console.log('Transcripts changed:', uvSession.transcripts);
+      appendToConversation(`Transcripts changed: ${JSON.stringify(uvSession.transcripts)}`);
     });
 
-    UVSession.addEventListener('experimental_message', (event) => {
+    uvSession.addEventListener('experimental_message', (event) => {
       console.log('Exp Message:', event);
     });
+
+    uvSession.joinCall(joinUrl);
+    appendToConversation(`Joining call: ${uvSession.status}`);
+    console.log('Session status:', uvSession.status);
+
+    
   }
 
 }
@@ -66,5 +68,5 @@ function appendToConversation(message) {
 
 export function endCall() {
   appendToConversation('Leaving call...');
-  UVSession.leaveCall();
+  uvSession.leaveCall();
 }

--- a/examples/quickstart-js/package.json
+++ b/examples/quickstart-js/package.json
@@ -19,6 +19,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "ultravox-client": "^0.2.15"
+    "ultravox-client": "^0.3.2"
   }
 }

--- a/examples/quickstart-js/pnpm-lock.yaml
+++ b/examples/quickstart-js/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^4.19.2
         version: 4.19.2
       ultravox-client:
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.3.2
+        version: 0.3.2
     devDependencies:
       vite:
         specifier: ^5.3.4
@@ -178,8 +178,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@livekit/protocol@1.19.1':
-    resolution: {integrity: sha512-PQYIuqRv++fRik9tKulJ0C0tT5O4cNviBA7OxwLTCBFDxJpve8ua8/JZ+nK+7r4j2KbLfVjsJYop9wcTCgRn7Q==}
+  '@livekit/protocol@1.24.0':
+    resolution: {integrity: sha512-9dCsqnkMn7lvbI4NGh18zhLDsrXyUcpS++TEFgEk5Xv1WM3R2kT3EzqgL1P/mr3jaabM6rJ8wZA/KJLuQNpF5w==}
 
   '@rollup/rollup-android-arm-eabi@4.20.0':
     resolution: {integrity: sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==}
@@ -496,8 +496,8 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  livekit-client@2.4.2:
-    resolution: {integrity: sha512-6iEeDiaon9TvH0L0t34wSApGk6In8Rpl538Dgh9hrxts2kq0scuxMTz2ipagFVIVGYOKceKBA2dnv/XOL+1ACw==}
+  livekit-client@2.5.9:
+    resolution: {integrity: sha512-oDpK6SKYB1F+mNO+25DA0bF0cD2XoOJeD8ji4YQpzDBQv2IxeyKrQhoqXAqrYgIKuiMNkImSf+yg2v7EHSl4Og==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -681,6 +681,9 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -688,8 +691,8 @@ packages:
   typed-emitter@2.1.0:
     resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
-  ultravox-client@0.2.15:
-    resolution: {integrity: sha512-rhklBYZHvtBlpXuvVD7mJycWdeJLfrujqzsyuq45uIjskZMjsUW6GPgxIYNi3egD3QfIGt8UMDmnPfepvBL7YA==}
+  ultravox-client@0.3.2:
+    resolution: {integrity: sha512-Z+j1efzyIxOVbjqo8ZcaQTKLoYbPRDa5EIwCcqK6r2CfP5xtKe3fBsiOs81mF0Eq4wyMtvOp8mapT+3S44z+5g==}
     engines: {pnpm: '>=6.0.0'}
 
   unpipe@1.0.0:
@@ -829,7 +832,7 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@livekit/protocol@1.19.1':
+  '@livekit/protocol@1.24.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
@@ -1160,14 +1163,14 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  livekit-client@2.4.2:
+  livekit-client@2.5.9:
     dependencies:
-      '@livekit/protocol': 1.19.1
+      '@livekit/protocol': 1.24.0
       events: 3.3.0
       loglevel: 1.9.1
       sdp-transform: 2.14.2
       ts-debounce: 4.0.0
-      tslib: 2.6.3
+      tslib: 2.7.0
       typed-emitter: 2.1.0
       webrtc-adapter: 9.0.1
 
@@ -1354,6 +1357,8 @@ snapshots:
 
   tslib@2.6.3: {}
 
+  tslib@2.7.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -1363,9 +1368,9 @@ snapshots:
     optionalDependencies:
       rxjs: 7.8.1
 
-  ultravox-client@0.2.15:
+  ultravox-client@0.3.2:
     dependencies:
-      livekit-client: 2.4.2
+      livekit-client: 2.5.9
 
   unpipe@1.0.0: {}
 

--- a/examples/simple-vanilla-html/UltravoxCall.html
+++ b/examples/simple-vanilla-html/UltravoxCall.html
@@ -84,7 +84,7 @@
 
 <script type="module">
   import { UltravoxSession } from 'https://esm.sh/ultravox-client@0.3.1';
-  let UVSession = new UltravoxSession();
+  let uvSession = new UltravoxSession();
 
   function appendUpdate(target, message) {
     const updateTarget = document.getElementById(target);
@@ -110,22 +110,23 @@
       return;
     } else {
       appendUpdate('callStatus', 'Starting call');
-      UVSession.joinCall(joinUrl);
-      appendUpdate('callStatus', `Joining call: ${UVSession.status}`);
 
-      UVSession.addEventListener('status', (event) => {
-        appendUpdate('callStatus', `Session status changed: ${UVSession.status}`);
+      uvSession.addEventListener('status', (event) => {
+        appendUpdate('callStatus', `Session status changed: ${uvSession.status}`);
       });
 
-      UVSession.addEventListener('transcripts', (event) => {
-        appendUpdate('callTranscript', UVSession.transcripts);
+      uvSession.addEventListener('transcripts', (event) => {
+        appendUpdate('callTranscript', uvSession.transcripts);
       });
+
+      uvSession.joinCall(joinUrl);
+      appendUpdate('callStatus', `Joining call: ${uvSession.status}`);
     }
   };
 
   // End Call button click event handler
   document.getElementById('endCall').onclick = async function() {
     appendUpdate('callStatus', 'Ending call');
-    UVSession.leaveCall();
+    uvSession.leaveCall();
   };
 </script>

--- a/examples/simple-vanilla-html/UltravoxCall.html
+++ b/examples/simple-vanilla-html/UltravoxCall.html
@@ -83,9 +83,8 @@
 </div>
 
 <script type="module">
-  import { UltravoxSession } from 'https://esm.sh/ultravox-client@0.2.12';
+  import { UltravoxSession } from 'https://esm.sh/ultravox-client@0.3.1';
   let UVSession = new UltravoxSession();
-  let state;
 
   function appendUpdate(target, message) {
     const updateTarget = document.getElementById(target);
@@ -111,15 +110,15 @@
       return;
     } else {
       appendUpdate('callStatus', 'Starting call');
-      state = await UVSession.joinCall(joinUrl);
-      appendUpdate('callStatus', `Joining call: ${state.getStatus()}`);
+      UVSession.joinCall(joinUrl);
+      appendUpdate('callStatus', `Joining call: ${UVSession.status}`);
 
-      state.addEventListener('ultravoxSessionStatusChanged', (event) => {
-        appendUpdate('callStatus', `Session status changed: ${event.state}`);
+      UVSession.addEventListener('status', (event) => {
+        appendUpdate('callStatus', `Session status changed: ${UVSession.status}`);
       });
 
-      state.addEventListener('ultravoxTranscriptsChanged', (event) => {
-        appendUpdate('callTranscript', event.transcripts);
+      UVSession.addEventListener('transcripts', (event) => {
+        appendUpdate('callTranscript', UVSession.transcripts);
       });
     }
   };


### PR DESCRIPTION
cleaned up the quickstart code on SDK page and moved all examples to use the 0.3.2 version of the SDK (no state).