### PR TITLE
Remove clientBufferSizeMs from sample code

### DIFF
--- a/guides/websockets.mdx
+++ b/guides/websockets.mdx
@@ -41,7 +41,6 @@ Creating a WebSocket-based call with Ultravox requires setting `medium` to `serv
                 serverWebSocket: {
                     inputSampleRate: 48000,
                     outputSampleRate: 48000,
-                    clientBufferSizeMs: 30000
                 }
             }
         })


### PR DESCRIPTION
In general clients should only increase this when they also handle playback clearing.