### PR TITLE
Adding defer_response and agent reaction

### DIFF
--- a/api-reference/tools/tools-history-get.mdx
+++ b/api-reference/tools/tools-history-get.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/tools/{tool_id}/history
+title: "Get Tool History"
+description: "Gets all calls that have used the specified tool"
+---

--- a/datamessages.mdx
+++ b/datamessages.mdx
@@ -55,6 +55,15 @@ A message containing text transcripts of user and agent utterances.
 A user message sent via text.
 - `type: "input_text_message"`
 - `text`: String. The content of the user message.
+- `defer_response`: Boolean. Optional. If set to true, allows adding text to the conversation history without inducing an immediate response from or interrupting the model. Useful for injecting additional inline instructions into the conversation. 
+  - **Note:** Can be used with the [Ultravox SDK](/essentials/sdk) or via a [Websocket](/guides/websockets) connection. To use with telephony, you must proxy the audio via websocket.
+
+**Examples: Using defer_response**
+|||
+| :------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Emphasizing the Task            | Provide instructions to the agent to emphasize what it should do.<br />e.g. `"Translate, don't respond"`           |
+| Moving the Conversation Forward | After N turns, tell the agent to try to close the sale or end the call.                                            |
+| Running Background Processes    | Allow the conversation to proceed while a background process runs, then have the agent become aware of the result. |
 
 ## SetOutputMedium
 Message sent by the client to set the server's output medium.

--- a/essentials/tools.mdx
+++ b/essentials/tools.mdx
@@ -505,16 +505,33 @@ These tool actions require setting a special response type.
 |------|------|
 | hang-up | Terminates the call. In addition to having Ultravox end the call after [periods of user inactivity](/api-reference/calls/overview#inactivitymessages), your custom tool can end the call. |
 | new-stage | Creates a new call stage. See [here](/guides/callstages) for more. |
+| agent_reaction | Determines how the agent reacts after a tool call. See [below](#controlling-agent-responses-to-tools) for more. |
 
 How you set the response type depends on if you are using a server/HTTP or a client tool:
 
 **Server/HTTP Tools**
 
-Server tools must respond with the `X-Ultravox-Response-Type` header set to either `hang-up` or `new-stage`
+Server tools must respond with the `X-Ultravox-Response-Type` header set to either `hang-up` or `new-stage`.
 
 **Client Tools**
 
 For client tools, set `responseType="hang-up"` or `responseType="new-stage"` on your `ClientToolResult` object.
+
+### Controlling Agent Responses to Tools
+By default, LLM inference runs immediately after a tool call. This has the effect of the agent speaking. This is typically the desired behavior for tools that gather information. For example, for a tool that gathers information, the agent might say something like, "Great, I've submitted your information."
+
+This can cause issues depending on how the agent uses the tool or if you want the agent to not speak over a tool call. Ultravox Realtime allows you to define how the agent reacts to a tool call using either the `X-Ultravox-Agent-Reaction` header (for server tools) or the `agent_reaction` response type (for client tools).
+
+| Reaction | Description |
+|------|------|
+| speaks | Agent will speak immediately after the tool call returns. This is the default behavior if agent reaction is not set. Should be used for tools that gather information. |
+| listens | Agent listens for user input and doesn't speak. |
+| speaks-once | Agent speaks only if it didn't speak immediately before the tool call. Prevents agent repeating things before and after the tool call. |
+
+For server/HTTP tools, use the `X-Ultravox-Agent-Reaction` header and set the value to `speaks` (the default), `listens`, or `speaks-once`.
+
+For client tools, set `agent_reaction="speaks"` (the default), `agent_reaction="listens"`, or `agent_reaction="speaks-once"` on your `ClientToolResult` object.
+
 
 ### Debugging
 The Ultravox SDK enables viewing [debug messages](/sdk-reference/introduction#debug-messages) for any active call. These messages include tool calls.

--- a/mint.json
+++ b/mint.json
@@ -173,7 +173,8 @@
         "api-reference/tools/tools-get",
         "api-reference/tools/tools-post",
         "api-reference/tools/tools-put",
-        "api-reference/tools/tools-delete"
+        "api-reference/tools/tools-delete",
+        "api-reference/tools/tools-history-get"
       ]
     },
     {


### PR DESCRIPTION
Added defer_response to data messages page. Agent reaction added to a new section in tools. Also added a stub for Get Tool History API.