### PR TITLE
Update jambonz link in sip.mdx

### DIFF
--- a/guides/sip.mdx
+++ b/guides/sip.mdx
@@ -95,5 +95,5 @@ Ultravox Realtime currently supports the following codecs for SIP:
 Using any other codec will cause calls to fail.
 
 ## Integrations
-* [jambonz](https://jambonz.org) enables SIP connections and has an integration for Ultravox. [Learn more](/essentials/telephony#provider-specific-integration).
+* [jambonz](https://jambonz.org) enables SIP connections and has an integration for Ultravox. [Learn more](/essentials/telephony#jambonz-portal-setup).
 * [Voximplant](https://voximplant.com/docs) Provides a native connector for Ultravox. [Learn more](https://voximplant.com/docs/guides/ai/ultravox)


### PR DESCRIPTION
Updating the jambonz link at the bottom of the _SIP Guide_ page to point to the relevant section of the _Telephony_ page: https://docs.ultravox.ai/essentials/telephony#jambonz-portal-setup

I have also tried https://docs.ultravox.ai/essentials/telephony#jambonz, but this didn't seem to target the "jambonz" tab. Please advise if I'm missing something.

Thank you.