### PR TITLE
Document shared secrets and custom headers for data connections

### DIFF
--- a/apps/securing-data-connections.mdx
+++ b/apps/securing-data-connections.mdx
@@ -5,11 +5,29 @@ icon: 'shield-check'
 ---
 import dcSecuring from '/snippets/code/data-connection-security.mdx'
 
-When you use a [data connection](/tools/custom/http-vs-client-tools#data-connection-tools), Ultravox connects to your WebSocket endpoint. Shared secrets let your server verify that incoming connections are genuinely from Ultravox and haven't been tampered with.
+When you use a [data connection](/tools/custom/http-vs-client-tools#data-connection-tools), Ultravox connects to your WebSocket endpoint. To ensure your server only accepts connections from Ultravox, you can use custom headers for simple token-based authentication or shared secrets for HMAC-SHA256 signature verification.
 
-## How It Works
+## Custom Headers
 
-Ultravox uses HMAC-SHA256 signatures to prove authenticity. When shared secrets are configured, every outbound data connection WebSocket request includes three headers:
+The simplest way to authenticate data connections is to pass headers that your server can check. Use the `headers` field in the data connection config to send literal key-value pairs on the outbound WebSocket connection.
+
+```js Data connection with custom headers
+{
+  "dataConnection": {
+    "websocketUrl": "wss://your-server.com/data",
+    "headers": {
+      "Authorization": "Bearer your-token",
+      "X-Custom-Header": "custom-value"
+    }
+  }
+}
+```
+
+Your server can then verify the header values before accepting the connection.
+
+## Shared Secrets
+
+For stronger verification, shared secrets let your server cryptographically verify that a connection is from Ultravox and hasn't been tampered with. Ultravox uses HMAC-SHA256 signatures — when shared secrets are configured, every outbound data connection WebSocket request includes three headers:
 
 | Header | Description |
 |--------|-------------|
@@ -23,7 +41,7 @@ The signature is computed as:
 HMAC-SHA256(secret, call_id + timestamp)
 ```
 
-## Setting Shared Secrets
+### Setting Shared Secrets
 
 Shared secrets can be set at the call level or on an agent's call template. Secrets must be between 16 and 127 characters. They are write-only and never returned in API responses.
 
@@ -64,7 +82,7 @@ const response = await fetch('https://api.ultravox.ai/api/agents', {
 
 Secrets set at call creation override those from the agent template.
 
-## Verifying Signatures
+### Verifying Signatures
 
 When your data connection server receives an incoming WebSocket connection from Ultravox, verify it with these steps:
 
@@ -91,20 +109,3 @@ When your data connection server receives an incoming WebSocket connection from 
   </Step>
 </Steps>
 
-## Custom Headers
-
-You can also pass additional headers on data connection WebSocket requests using the `headers` field in the data connection config. These are sent as literal key-value pairs.
-
-```js Data connection with custom headers
-{
-  "dataConnection": {
-    "websocketUrl": "wss://your-server.com/data",
-    "headers": {
-      "Authorization": "Bearer your-token",
-      "X-Custom-Header": "custom-value"
-    }
-  }
-}
-```
-
-Custom headers and shared secret signatures can be used together. When both are configured, all headers are included in the outbound WebSocket connection.

--- a/apps/securing-data-connections.mdx
+++ b/apps/securing-data-connections.mdx
@@ -1,0 +1,110 @@
+---
+title: 'Securing Data Connections'
+description: 'Learn how to verify that data connection WebSocket requests are authentically from Ultravox.'
+icon: 'shield-check'
+---
+import dcSecuring from '/snippets/code/data-connection-security.mdx'
+
+When you use a [data connection](/tools/custom/http-vs-client-tools#data-connection-tools), Ultravox connects to your WebSocket endpoint. Shared secrets let your server verify that incoming connections are genuinely from Ultravox and haven't been tampered with.
+
+## How It Works
+
+Ultravox uses HMAC-SHA256 signatures to prove authenticity. When shared secrets are configured, every outbound data connection WebSocket request includes three headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-Ultravox-Call-ID` | The UUID of the call initiating the connection. |
+| `X-Ultravox-Signature-Timestamp` | ISO 8601 UTC timestamp of when the connection was made. |
+| `X-Ultravox-Signature` | HMAC-SHA256 signature(s), comma-separated if multiple secrets are configured. |
+
+The signature is computed as:
+
+```
+HMAC-SHA256(secret, call_id + timestamp)
+```
+
+## Setting Shared Secrets
+
+Shared secrets can be set at the call level or on an agent's call template. Secrets must be between 16 and 127 characters. They are write-only and never returned in API responses.
+
+```js Setting shared secrets during call creation
+const response = await fetch('https://api.ultravox.ai/api/calls', {
+  method: 'POST',
+  headers: {
+    'X-API-Key': 'your_api_key',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    systemPrompt: "You are a helpful assistant...",
+    model: "ultravox-v0.7",
+    dataConnection: {
+      websocketUrl: "wss://your-server.com/data"
+    },
+    sharedSecrets: ["your-secret-at-least-16-chars"]
+  })
+});
+```
+
+```js Setting shared secrets on an agent template
+const response = await fetch('https://api.ultravox.ai/api/agents', {
+  method: 'POST',
+  headers: {
+    'X-API-Key': 'your_api_key',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    name: "My Agent",
+    callTemplate: {
+      systemPrompt: "You are a helpful assistant...",
+      sharedSecrets: ["your-secret-at-least-16-chars"]
+    }
+  })
+});
+```
+
+Secrets set at call creation override those from the agent template.
+
+## Verifying Signatures
+
+When your data connection server receives an incoming WebSocket connection from Ultravox, verify it with these steps:
+
+<Steps>
+  <Step title="Timestamp Verification">
+    * The `X-Ultravox-Signature-Timestamp` header contains the time the connection was initiated.
+    * Verify that this timestamp is recent (e.g. within the last minute) to prevent replay attacks.
+  </Step>
+  <Step title="Signature Verification">
+    * Ultravox signs each connection using HMAC-SHA256.
+    * The signature is in the `X-Ultravox-Signature` header.
+    * To verify:
+      * Concatenate the call ID (`X-Ultravox-Call-ID`) with the timestamp.
+      * Create an HMAC-SHA256 hash using your shared secret as the key.
+      * Compare this hash with the provided signature.
+
+    <dcSecuring />
+
+  </Step>
+  <Step title="Multiple Signatures">
+    * The `X-Ultravox-Signature` header may contain multiple comma-separated signatures.
+    * This supports key rotation without downtime — configure both old and new secrets, then remove the old one once your server is updated.
+    * Your server should check if **any** of the provided signatures match.
+  </Step>
+</Steps>
+
+## Custom Headers
+
+You can also pass additional headers on data connection WebSocket requests using the `headers` field in the data connection config. These are sent as literal key-value pairs.
+
+```js Data connection with custom headers
+{
+  "dataConnection": {
+    "websocketUrl": "wss://your-server.com/data",
+    "headers": {
+      "Authorization": "Bearer your-token",
+      "X-Custom-Header": "custom-value"
+    }
+  }
+}
+```
+
+Custom headers and shared secret signatures can be used together. When both are configured, all headers are included in the outbound WebSocket connection.

--- a/docs.json
+++ b/docs.json
@@ -91,7 +91,7 @@
           {
             "group": "Web, Apps, Websockets",
             "icon": "window",
-            "pages": ["apps/overview", "/apps/sdks", "apps/websockets", "apps/datamessages"]
+            "pages": ["apps/overview", "/apps/sdks", "apps/websockets", "apps/datamessages", "apps/securing-data-connections"]
           },
           {
             "group": "Tools",

--- a/snippets/code/data-connection-security.mdx
+++ b/snippets/code/data-connection-security.mdx
@@ -1,0 +1,15 @@
+```python Verifying Data Connection Signature
+import datetime
+import hmac
+
+call_id = request.headers["X-Ultravox-Call-ID"]
+timestamp = request.headers["X-Ultravox-Signature-Timestamp"]
+if datetime.datetime.now(datetime.timezone.utc) - datetime.datetime.fromisoformat(timestamp) > datetime.timedelta(minutes=1):
+  raise RuntimeError("Expired message")
+expected_signature = hmac.new(SHARED_SECRET.encode(), (call_id + timestamp).encode(), "sha256").hexdigest()
+for signature in request.headers["X-Ultravox-Signature"].split(","):
+  if hmac.compare_digest(signature.strip(), expected_signature):
+    break  # Valid signature
+else:
+  raise RuntimeError("Invalid signature")
+```

--- a/tools/custom/http-vs-client-tools.mdx
+++ b/tools/custom/http-vs-client-tools.mdx
@@ -235,4 +235,4 @@ Data connection tools are ideal for:
 
 **Client Tools**: No built-in authentication - handle security in your client application.
 
-**Data Connection Tools**: Authentication handled via websocket connection setup.
+**Data Connection Tools**: Use [shared secrets](/apps/securing-data-connections) for HMAC-SHA256 signature verification, and/or pass [custom headers](/apps/securing-data-connections#custom-headers) on the WebSocket connection.

--- a/tools/custom/http-vs-client-tools.mdx
+++ b/tools/custom/http-vs-client-tools.mdx
@@ -233,6 +233,6 @@ Data connection tools are ideal for:
 
 **HTTP Tools**: Full authentication support including API keys, tokens, and custom headers. See [Tools Authentication →](./authentication)
 
-**Client Tools**: No built-in authentication - handle security in your client application.
+**Client Tools**: The client that joins the call is implicitly trusted — it connected using the call's join URL, which serves as proof of authorization.
 
-**Data Connection Tools**: Use [shared secrets](/apps/securing-data-connections) for HMAC-SHA256 signature verification, and/or pass [custom headers](/apps/securing-data-connections#custom-headers) on the WebSocket connection.
+**Data Connection Tools**: Ultravox trusts data connections specified during call creation. There's no additional per-tool authentication. To ensure your server only handles WebSocket connections from Ultravox, see [Securing Data Connections →](/apps/securing-data-connections).


### PR DESCRIPTION
## Summary
- Adds a new **Securing Data Connections** page (`apps/securing-data-connections.mdx`) documenting HMAC-SHA256 shared secret signing and custom headers for data connection WebSocket requests.
- Includes a reusable Python verification code snippet mirroring the existing webhook security snippet.
- Updates the data connection authentication description in `tools/custom/http-vs-client-tools.mdx` to link to the new page.
- Adds the new page to the site navigation in `docs.json`.

## Test plan
- [x] Verify the new page renders correctly in Mintlify
- [x] Confirm navigation link appears under "Web, Apps, Websockets"
- [x] Check that cross-links from `http-vs-client-tools.mdx` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)