### PR TITLE
Add Call Throttles endpoints to API reference

### DIFF
--- a/api-reference/call-throttles/call-throttles-delete.mdx
+++ b/api-reference/call-throttles/call-throttles-delete.mdx
@@ -1,0 +1,5 @@
+---
+openapi: delete /api/call_throttles/{throttle_id}
+title: "Delete Call Throttle"
+description: "Deletes a call throttle"
+---

--- a/api-reference/call-throttles/call-throttles-get.mdx
+++ b/api-reference/call-throttles/call-throttles-get.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/call_throttles/{throttle_id}
+title: "Get Call Throttle"
+description: "Gets a call throttle"
+---

--- a/api-reference/call-throttles/call-throttles-list.mdx
+++ b/api-reference/call-throttles/call-throttles-list.mdx
@@ -1,0 +1,5 @@
+---
+openapi: get /api/call_throttles
+title: "List Call Throttles"
+description: "Lists call throttles for the current account"
+---

--- a/api-reference/call-throttles/call-throttles-patch.mdx
+++ b/api-reference/call-throttles/call-throttles-patch.mdx
@@ -1,0 +1,5 @@
+---
+openapi: patch /api/call_throttles/{throttle_id}
+title: "Patch Call Throttle"
+description: "Partially updates a call throttle"
+---

--- a/api-reference/call-throttles/call-throttles-post.mdx
+++ b/api-reference/call-throttles/call-throttles-post.mdx
@@ -1,0 +1,5 @@
+---
+openapi: post /api/call_throttles
+title: "Create Call Throttle"
+description: "Creates a new call throttle"
+---

--- a/api-reference/call-throttles/call-throttles-put.mdx
+++ b/api-reference/call-throttles/call-throttles-put.mdx
@@ -1,0 +1,5 @@
+---
+openapi: put /api/call_throttles/{throttle_id}
+title: "Update Call Throttle"
+description: "Updates a call throttle"
+---

--- a/docs.json
+++ b/docs.json
@@ -245,6 +245,17 @@
             ]
           },
           {
+            "group": "Call Throttles",
+            "pages": [
+              "api-reference/call-throttles/call-throttles-list",
+              "api-reference/call-throttles/call-throttles-get",
+              "api-reference/call-throttles/call-throttles-post",
+              "api-reference/call-throttles/call-throttles-put",
+              "api-reference/call-throttles/call-throttles-patch",
+              "api-reference/call-throttles/call-throttles-delete"
+            ]
+          },
+          {
             "group": "Tools",
             "pages": [
               "api-reference/tools/tools-list",


### PR DESCRIPTION
## Summary
- Adds stub MDX pages for the six `/api/call_throttles` CRUD endpoints (list, get, create, update, patch, delete).
- Adds a new "Call Throttles" group to the API Reference sidebar in `docs.json`, between Calls and Tools.

## Test plan
- [ ] Verify Mintlify build picks up the new pages and renders them with schema details from the OpenAPI spec.