### PR TITLE
Don't bill SIP minutes for ringing time

### DIFF
--- a/telephony/sip.mdx
+++ b/telephony/sip.mdx
@@ -170,15 +170,16 @@ When you create the call, Ultravox will automatically send a SIP invite using th
 
 Serving SIP calls requires additional infrastructure (provided by our SIP partner, Voximplant). Consequently, SIP
 calls incur costs for SIP minutes in addition to the regular cost of call minutes. Like call minutes, SIP minutes are billed
-per-deciminute (i.e. six second increments), rounded up to the nearest deciminute. Unlike call minutes, **SIP minutes are
-billed when SIP infrastructure is active**, not just while your agent is connected to a user. In particular, **outgoing calls
-are billed from the start of the call, not the point at which your user answers**. This means that an outgoing SIP call may
-be billed for 0 minutes and non-zero SIP minutes if the call is not answered.
+per-deciminute (i.e. six second increments), rounded up to the nearest deciminute. Unlike call minutes, **SIP minutes can be
+billed even when your agent is not connected to a user** — for example, transfer legs that keep running after your agent leaves
+the call. **Ringing time is not billed**, though: an outgoing call only begins accruing SIP minutes once it is answered, so a
+call that is never answered incurs no SIP minutes.
 
 See https://ultravox.ai/pricing for current rates for SIP minutes.
 
 The examples below illustrate how different call scenarios affect SIP billing. Red blocks correspond to segments of the call
-that count toward the SIP duration while the blue block shows when your agent is connected (i.e. regular call minutes).
+that count toward the SIP duration, grey blocks (ringing) are not billed, and the blue block shows when your agent is connected
+(i.e. regular call minutes).
 
 ```mermaid
 gantt
@@ -187,7 +188,7 @@ gantt
     axisFormat %M:%S.%L
 
     section SIP Call
-    Ringing                    :crit, 0, 20000ms
+    Ringing                    :done, 0, 20000ms
     Talking to Agent           :crit, 120000ms
 
     section Agent
@@ -221,7 +222,7 @@ gantt
     axisFormat %M:%S.%L
 
     section SIP Call
-    Ringing                    :crit, 0, 20000ms
+    Ringing                    :done, 0, 20000ms
     Talking to Agent           :crit, 60000ms
     Refer ringing              :crit, 10000ms
     Talking to Transfer Target -> :crit, 0ms
@@ -239,13 +240,13 @@ gantt
     axisFormat %M:%S.%L
 
     section Initial Call
-    Ringing                    :crit, 0, 20000ms
+    Ringing                    :done, 0, 20000ms
     Talking to Agent           :crit, 30000ms
     On Hold                    :crit, 10000ms
     Talking to Transfer Target :crit, 300000ms
 
     section Transfer Call
-    Ringing                    :crit, 50000, 10000ms
+    Ringing                    :done, 50000, 10000ms
     Talking to Initial User    :crit, 300000ms
 
     section Agent
@@ -261,13 +262,13 @@ gantt
     axisFormat %M:%S.%L
 
     section Initial Call
-    Ringing                       :crit, 0, 20000ms
+    Ringing                       :done, 0, 20000ms
     Talking to Agent              :crit, 30000ms
     On Hold                       :crit, 50000ms
     Talking to Transfer Target -> :crit, 0ms
 
     section Transfer Call
-    Ringing                    :crit, 50000, 10000ms
+    Ringing                    :done, 50000, 10000ms
     Talking to Agent           :crit, 40000ms
     Talking to Initial User -> :crit, 0ms
 
@@ -282,13 +283,13 @@ gantt
     axisFormat %M:%S.%L
 
     section Initial Call
-    Ringing                    :crit, 0, 20000ms
+    Ringing                    :done, 0, 20000ms
     Talking to Agent           :crit, 30000ms
     On Hold                    :crit, 50000ms
     Talking to Agent           :crit, 30000ms
 
     section Transfer Call
-    Ringing                    :crit, 50000, 10000ms
+    Ringing                    :done, 50000, 10000ms
     Talking to Agent           :crit, 40000ms
 
     section Agent
@@ -304,13 +305,13 @@ gantt
     axisFormat %M:%S.%L
 
     section Initial Call
-    Ringing                    :crit, 0, 20000ms
+    Ringing                    :done, 0, 20000ms
     Talking to Agent           :crit, 30000ms
     On Hold                    :crit, 50000ms
     Talking to Transfer Target :crit, 300000ms
 
     section Transfer Call
-    Ringing                    :crit, 50000, 10000ms
+    Ringing                    :done, 50000, 10000ms
     Talking to Agent           :crit, 40000ms
     Talking to Initial User    :crit, 300000ms
 
@@ -321,9 +322,9 @@ gantt
 * **Warm transfer with TRY_REFER**: This will attempt to behave as in the REFER case, but will fallback to the bridged case (and thus cause additional SIP costs) if the REFER fails.
 
 <Note>
-  <b>Uncounted SIP time</b>
+  <b>Ringing is never billed</b>
   <br />
-  Due to some technical limitations, outgoing SIP calls with transfers may not be billed for the full ring time. This will only ever decrease the billed SIP duration.
+  The SIP clock for a given call leg only starts once that leg is answered, so ringing time (shown in grey above) is never counted toward your SIP minutes. This applies to both the initial call and any transfer legs.
 </Note>
 
 

--- a/telephony/sip.mdx
+++ b/telephony/sip.mdx
@@ -325,7 +325,7 @@ gantt
   <b>Ringing is no longer billed</b>
   <br />
   The SIP clock for a given call leg only starts once that leg is answered, so ringing time (shown in grey above) is never counted toward your SIP minutes. This applies to both the initial call and any transfer legs.
-  However call time for the initial call leg used to be billed, so you may see that on invoices through July 2026. Unfortunately we cannot apply this cost reduction retroactively.
+  However ring time for the initial call leg used to be billed, so you may see that on invoices through July 2026. Unfortunately we cannot apply this cost reduction retroactively.
 </Note>
 
 

--- a/telephony/sip.mdx
+++ b/telephony/sip.mdx
@@ -172,7 +172,7 @@ Serving SIP calls requires additional infrastructure (provided by our SIP partne
 calls incur costs for SIP minutes in addition to the regular cost of call minutes. Like call minutes, SIP minutes are billed
 per-deciminute (i.e. six second increments), rounded up to the nearest deciminute. Unlike call minutes, **SIP minutes can be
 billed even when your agent is not connected to a user** — for example, transfer legs that keep running after your agent leaves
-the call. **Ringing time is not billed**, though: an outgoing call only begins accruing SIP minutes once it is answered, so a
+the call. **Ringing time is not billed** though: an outgoing call only begins accruing SIP minutes once it is answered, so a
 call that is never answered incurs no SIP minutes.
 
 See https://ultravox.ai/pricing for current rates for SIP minutes.
@@ -322,9 +322,10 @@ gantt
 * **Warm transfer with TRY_REFER**: This will attempt to behave as in the REFER case, but will fallback to the bridged case (and thus cause additional SIP costs) if the REFER fails.
 
 <Note>
-  <b>Ringing is never billed</b>
+  <b>Ringing is no longer billed</b>
   <br />
   The SIP clock for a given call leg only starts once that leg is answered, so ringing time (shown in grey above) is never counted toward your SIP minutes. This applies to both the initial call and any transfer legs.
+  However call time for the initial call leg used to be billed, so you may see that on invoices through July 2026. Unfortunately we cannot apply this cost reduction retroactively.
 </Note>
 
 


### PR DESCRIPTION
## Summary

Documents the billing change in fixie-ai/fixie#4605: We no longer bill customers for ring time.

## Changes to the SIP Billing section

- **Intro paragraph reframed.** Removed the old claims that outgoing calls "are billed from the start of the call, not the point at which your user answers" and that an unanswered call bills non-zero SIP minutes — both are now false. The new text states that SIP minutes start accruing once a leg is answered, an unanswered outgoing call incurs no SIP minutes, and SIP minutes can still extend beyond the agent's connection (e.g. transfer legs that continue after the agent leaves).
- **Diagrams updated.** Every initial- and transfer-leg ringing block is now grey/unbilled (`done` instead of `crit`) across all seven gantt charts, and the legend explains the grey blocks. **"Refer ringing" intentionally stays billed (red)** — during a REFER the original leg is still connected, so that time is part of its billable duration.
- **Note replaced.** The old "Uncounted SIP time" note (which warned that transfer ring time *may* not be fully billed) is replaced with "Ringing is no longer billed," since that's now the general rule.

## Why "Refer ringing" stays billed

The SIP clock for a leg runs from answer → disconnect. During a referred transfer, the original leg remains connected while the transfer target rings, so the original leg's billable duration includes the refer-ringing window. Only ringing *before a leg is answered* (the initial outbound ring and each transfer leg's own pre-answer ring) is unbilled.

Pairs with fixie-ai/fixie#4605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)